### PR TITLE
Fix admin login redirect loop by allowing unauthenticated access

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -13,6 +13,11 @@ function acceptsRSC(req: NextRequest) {
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
+  // Allow unauthenticated access to the admin login page (avoid redirect loop)
+  if (pathname === "/admin/login" || pathname.startsWith("/admin/login/")) {
+    return NextResponse.next()
+  }
+
   // Only protect /admin and /api/admin routes
   if (!pathname.startsWith("/admin") && !pathname.startsWith("/api/admin")) {
     return NextResponse.next()


### PR DESCRIPTION
## Purpose

Users were experiencing an `ERR_TOO_MANY_REDIRECTS` error when trying to access the admin login page. The conversation history shows users were trying to review the `/admin/login` route and encountered runtime errors with redirect loops preventing access to the admin authentication system.

## Code changes

- Added exception in middleware to allow unauthenticated access to `/admin/login` and `/admin/login/*` routes
- Prevents redirect loop by bypassing authentication checks for the login page itself
- Maintains protection for all other `/admin` and `/api/admin` routes

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f3b8d6da249c47779fce1f3bebfa75eb/spark-sanctuary)

👀 [Preview Link](https://f3b8d6da249c47779fce1f3bebfa75eb-spark-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f3b8d6da249c47779fce1f3bebfa75eb</projectId>-->
<!--<branchName>spark-sanctuary</branchName>-->